### PR TITLE
Use CodeID instead of ContractID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -43,8 +43,8 @@ func Create(cache Cache, wasm []byte) ([]byte, error) {
 	return receiveSlice(id), nil
 }
 
-func GetCode(cache Cache, contractID []byte) ([]byte, error) {
-	id := sendSlice(contractID)
+func GetCode(cache Cache, code_id []byte) ([]byte, error) {
+	id := sendSlice(code_id)
 	errmsg := C.Buffer{}
 	code, err := C.get_code(cache.ptr, id, &errmsg)
 	if err != nil {
@@ -53,8 +53,8 @@ func GetCode(cache Cache, contractID []byte) ([]byte, error) {
 	return receiveSlice(code), nil
 }
 
-func Instantiate(cache Cache, contractID []byte, params []byte, msg []byte, store KVStore, gasLimit int64) ([]byte, error) {
-	id := sendSlice(contractID)
+func Instantiate(cache Cache, code_id []byte, params []byte, msg []byte, store KVStore, gasLimit int64) ([]byte, error) {
+	id := sendSlice(code_id)
 	p := sendSlice(params)
 	m := sendSlice(msg)
 	db := buildDB(store)
@@ -66,8 +66,8 @@ func Instantiate(cache Cache, contractID []byte, params []byte, msg []byte, stor
 	return receiveSlice(res), nil
 }
 
-func Handle(cache Cache, contractID []byte, params []byte, msg []byte, store KVStore, gasLimit int64) ([]byte, error) {
-	id := sendSlice(contractID)
+func Handle(cache Cache, code_id []byte, params []byte, msg []byte, store KVStore, gasLimit int64) ([]byte, error) {
+	id := sendSlice(code_id)
 	p := sendSlice(params)
 	m := sendSlice(msg)
 	db := buildDB(store)
@@ -79,8 +79,8 @@ func Handle(cache Cache, contractID []byte, params []byte, msg []byte, store KVS
 	return receiveSlice(res), nil
 }
 
-func Query(cache Cache, contractID []byte, path []byte, data []byte, store KVStore, gasLimit int64) ([]byte, error) {
-	id := sendSlice(contractID)
+func Query(cache Cache, code_id []byte, path []byte, data []byte, store KVStore, gasLimit int64) ([]byte, error) {
+	id := sendSlice(code_id)
 	p := sendSlice(path)
 	d := sendSlice(data)
 	db := buildDB(store)

--- a/lib.go
+++ b/lib.go
@@ -8,24 +8,27 @@ import (
 	"github.com/confio/go-cosmwasm/types"
 )
 
-// ContractID represents an ID for a contract, must be generated from this library
-type ContractID []byte
+// CodeID represents an ID for a given wasm code blob, must be generated from this library
+type CodeID []byte
 
 // WasmCode is an alias for raw bytes of the wasm compiled code
 type WasmCode []byte
 
-// KVStore is a reference to some sub-kvstore that is valid for one instance of a contract
+// KVStore is a reference to some sub-kvstore that is valid for one instance of a code
 type KVStore = api.KVStore
 
 // Wasmer is the main entry point to this library.
 // You should create an instance with it's own subdirectory to manage state inside,
-// and call it for all cosmwasm contract related actions.
+// and call it for all cosmwasm code related actions.
 type Wasmer struct {
 	cache api.Cache
 }
 
 // NewWasmer creates an new binding, with the given dataDir where
-// it can store raw wasm and the pre-compile cache
+// it can store raw wasm and the pre-compile cache.
+// cacheSize sets the size of an optional in-memory LRU cache for prepared VMs.
+// They allow popular contracts to be executed very rapidly (no loading overhead),
+// but require ~32-64MB each in memory usage.
 func NewWasmer(dataDir string, cacheSize uint64) (*Wasmer, error) {
 	cache, err := api.InitCache(dataDir, cacheSize)
 	if err != nil {
@@ -40,40 +43,43 @@ func (w *Wasmer)Cleanup() {
 }
 
 // Create will compile the wasm code, and store the resulting pre-compile
-// as well as the original code. Both can be referenced later via ContractID
+// as well as the original code. Both can be referenced later via CodeID
 // This must be done one time for given code, after which it can be
 // instatitated many times, and each instance called many times.
 //
 // TODO: return gas cost? Add gas limit??? there is no metering here...
-func (w *Wasmer) Create(contract WasmCode) (ContractID, error) {
-	return api.Create(w.cache, contract)
+func (w *Wasmer) Create(code WasmCode) (CodeID, error) {
+	return api.Create(w.cache, code)
 }
 
-// GetCode will load the original wasm code for the given contract id.
-// This will only succeed if that contract id was previously returned from
+// GetCode will load the original wasm code for the given code id.
+// This will only succeed if that code id was previously returned from
 // a call to Create.
 //
-// This can be used so that the (short) contract id (hash) is stored in the iavl tree
+// This can be used so that the (short) code id (hash) is stored in the iavl tree
 // and the larger binary blobs (wasm and pre-compiles) are all managed by the
 // rust library
-func (w *Wasmer) GetCode(contract ContractID) (WasmCode, error) {
-	return api.GetCode(w.cache, contract)
+func (w *Wasmer) GetCode(code CodeID) (WasmCode, error) {
+	return api.GetCode(w.cache, code)
 }
 
-// Instantiate will create a new instance of a contract using the given contractID.
-// storage should be set with a PrefixedKVStore that this contract can safely access.
+// Instantiate will create a new contract based on the given codeID.
+// We can set the initMsg (contract "genesis") here, and it then receives
+// an account and address and can be invoked (Handle) many times.
+//
+// storage should be set with a PrefixedKVStore that this code can safely access.
 //
 // Under the hood, we may recompile the wasm, use a cached native compile, or even use a cached instance
 // for performance.
 //
-// TODO: clarify which errors are returned? vm failure. out of gas. contract unauthorized.
+// TODO: clarify which errors are returned? vm failure. out of gas. code unauthorized.
 // TODO: add callback for querying into other modules
-func (w *Wasmer) Instantiate(contract ContractID, params types.Params, userMsg []byte, store KVStore, gasLimit int64) (*types.Result, error) {
+func (w *Wasmer) Instantiate(code CodeID, params types.Params, initMsg []byte, store KVStore, gasLimit int64) (*types.Result, error) {
 	paramBin, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
 	}
-	data, err := api.Instantiate(w.cache, contract, paramBin, userMsg, store, gasLimit)
+	data, err := api.Instantiate(w.cache, code, paramBin, initMsg, store, gasLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -89,18 +95,20 @@ func (w *Wasmer) Instantiate(contract ContractID, params types.Params, userMsg [
 	return &resp.Ok, nil
 }
 
-// Handle calls a given instance of the contract. Since the only difference between the instances is the data in their
-// local storage, and their address in the outside world, we need no InstanceID.
+// Handle calls a given contract. Since the only difference between contracts with the same CodeID is the
+// data in their local storage, and their address in the outside world, we need no ContractID here.
+// (That is a detail for the external, sdk-facing, side).
+//
 // The caller is responsible for passing the correct `store` (which must have been initialized exactly once),
 // and setting the params with relevent info on this instance (address, balance, etc)
 //
 // TODO: add callback for querying into other modules
-func (w *Wasmer) Handle(contract ContractID, params types.Params, userMsg []byte, store KVStore, gasLimit int64) (*types.Result, error) {
+func (w *Wasmer) Handle(code CodeID, params types.Params, handleMsg []byte, store KVStore, gasLimit int64) (*types.Result, error) {
 	paramBin, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
 	}
-	data, err := api.Handle(w.cache, contract, paramBin, userMsg, store, gasLimit)
+	data, err := api.Handle(w.cache, code, paramBin, handleMsg, store, gasLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +126,8 @@ func (w *Wasmer) Handle(contract ContractID, params types.Params, userMsg []byte
 
 // Query allows a client to execute a contract-specific query. If the result is not empty, it should be
 // valid json-encoded data to return to the client.
-// The meaning of path and data can be determined by the contract. Path is the suffix of the abci.QueryRequest.Path
-func (w *Wasmer) Query(contract ContractID, path []byte, data []byte, store KVStore, gasLimit int64) ([]byte, error) {
+// The meaning of path and data can be determined by the code. Path is the suffix of the abci.QueryRequest.Path
+func (w *Wasmer) Query(code CodeID, path []byte, data []byte, store KVStore, gasLimit int64) ([]byte, error) {
 	panic("unimplemented!")
 	// TODO
 	return nil, nil


### PR DESCRIPTION
Plus a little cleanup on variable names.

Should we also change some of the method names?

I think to use the following terms:

* `Code` is what we "create"
* `Contract` is what we "instantiate" and "execute" 