### PR TITLE
Updated naming and comments

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -69,7 +69,7 @@ func (w *Wasmer) GetCode(code CodeID) (WasmCode, error) {
 
 // Instantiate will create a new contract based on the given codeID.
 // We can set the initMsg (contract "genesis") here, and it then receives
-// an account and address and can be invoked (Handle) many times.
+// an account and address and can be invoked (Execute) many times.
 //
 // Storage should be set with a PrefixedKVStore that this code can safely access.
 //
@@ -99,7 +99,7 @@ func (w *Wasmer) Instantiate(code CodeID, params types.Params, initMsg []byte, s
 	return &resp.Ok, nil
 }
 
-// Handle calls a given contract. Since the only difference between contracts with the same CodeID is the
+// Execute calls a given contract. Since the only difference between contracts with the same CodeID is the
 // data in their local storage, and their address in the outside world, we need no ContractID here.
 // (That is a detail for the external, sdk-facing, side).
 //
@@ -107,12 +107,12 @@ func (w *Wasmer) Instantiate(code CodeID, params types.Params, initMsg []byte, s
 // and setting the params with relevent info on this instance (address, balance, etc)
 //
 // TODO: add callback for querying into other modules
-func (w *Wasmer) Handle(code CodeID, params types.Params, handleMsg []byte, store KVStore, gasLimit int64) (*types.Result, error) {
+func (w *Wasmer) Execute(code CodeID, params types.Params, executeMsg []byte, store KVStore, gasLimit int64) (*types.Result, error) {
 	paramBin, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
 	}
-	data, err := api.Handle(w.cache, code, paramBin, handleMsg, store, gasLimit)
+	data, err := api.Handle(w.cache, code, paramBin, executeMsg, store, gasLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/lib.go
+++ b/lib.go
@@ -38,7 +38,7 @@ func NewWasmer(dataDir string, cacheSize uint64) (*Wasmer, error) {
 }
 
 // Cleanup should be called when no longer using this to free resources on the rust-side
-func (w *Wasmer)Cleanup() {
+func (w *Wasmer) Cleanup() {
 	api.ReleaseCache(w.cache)
 }
 
@@ -46,6 +46,10 @@ func (w *Wasmer)Cleanup() {
 // as well as the original code. Both can be referenced later via CodeID
 // This must be done one time for given code, after which it can be
 // instatitated many times, and each instance called many times.
+//
+// For example, the code for all ERC-20 contracts should be the same.
+// This function stores the code for that contract only once, but it can
+// be instantiated with custom inputs in the future.
 //
 // TODO: return gas cost? Add gas limit??? there is no metering here...
 func (w *Wasmer) Create(code WasmCode) (CodeID, error) {
@@ -67,7 +71,7 @@ func (w *Wasmer) GetCode(code CodeID) (WasmCode, error) {
 // We can set the initMsg (contract "genesis") here, and it then receives
 // an account and address and can be invoked (Handle) many times.
 //
-// storage should be set with a PrefixedKVStore that this code can safely access.
+// Storage should be set with a PrefixedKVStore that this code can safely access.
 //
 // Under the hood, we may recompile the wasm, use a cached native compile, or even use a cached instance
 // for performance.

--- a/spec/Specification.md
+++ b/spec/Specification.md
@@ -49,10 +49,10 @@ As discussed above, all data structures passed between web assembly and the cosm
 The actual call to create a new contract (upload code) is quite simple, and returns a `ContractID` to be used in all future calls:
 `Create(contract WasmCode) (ContractID, error)`
 
-Both Instantiating a contract, as well as invoking a contract (`Handle` method) have similar interfaces. The difference is that `Instantiate` requires the `store` to be empty, while `Handle` requires it to be non-empty:
+Both Instantiating a contract, as well as invoking a contract (`Execute` method) have similar interfaces. The difference is that `Instantiate` requires the `store` to be empty, while `Execute` requires it to be non-empty:
 
 * `Instantiate(contract ContractID, params Params, userMsg []byte, store KVStore, gasLimit int64) (res *Result, err error)`
-* `Handle(contract ContractID, params Params, userMsg []byte, store KVStore, gasLimit int64) (res *Result, err error)`
+* `Execute(contract ContractID, params Params, userMsg []byte, store KVStore, gasLimit int64) (res *Result, err error)`
 
 We also expose a Query method to respond to abci.QueryRequests:
 
@@ -168,7 +168,7 @@ type ContractMsg struct {
     // the contract ID and instance ID. The sdk module should maintain a reverse lookup table. 
     ContractAddr string `json:"contract_addr"`
     // Msg is assumed to be a json-encoded message, which will be passed directly
-    // as `userMsg` when calling `Handle` on the above-defined contract
+    // as `userMsg` when calling `Execute` on the above-defined contract
     Msg string `json:"msg"`
 }
 


### PR DESCRIPTION
* Added some comments
* Renamed Handle to Execute because I think it describes the action better. Handle could also be confused with Cosmos SDK handlers. It's nice to have an explicit difference for contracts.
* Updated docs